### PR TITLE
Fix/image crop when slide right

### DIFF
--- a/app/script/main.js
+++ b/app/script/main.js
@@ -4026,7 +4026,7 @@ var drawImage = function drawImage() {
 
   var images = gallery.images;
 
-  canvas.drawImage(images[index], mouseDistance);
+  canvas.drawMainImage(images[index], mouseDistance);
   canvas.drawNextImage(images[nextIndex()], mouseDistance);
 };
 
@@ -10609,39 +10609,58 @@ function Canvas() {
     return { resizedWidth: resizedWidth, resizedHeight: resizedHeight };
   };
 
-  this.drawImage = function (image, mouseDragDistance) {
+  this.draw = function (image, _ref) {
+    var sx = _ref.sx,
+        sy = _ref.sy,
+        sw = _ref.sw,
+        sh = _ref.sh,
+        dx = _ref.dx,
+        dy = _ref.dy,
+        dw = _ref.dw,
+        dh = _ref.dh;
+
+    getContext().drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
+  };
+
+  this.dimensionsToDraw = function (image, mouseDragDistance) {
     var _scaleToFit = _this.scaleToFit(image),
         resizedWidth = _scaleToFit.resizedWidth,
         resizedHeight = _scaleToFit.resizedHeight;
 
-    var dx = _this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance;
-    var dy = _this.imageMargin(resizedHeight, MAX_HEIGHT);
+    return {
+      sx: 0,
+      sy: 0,
+      sw: image.width,
+      sh: image.height,
+      dx: _this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance,
+      dy: _this.imageMargin(resizedHeight, MAX_HEIGHT),
+      dw: resizedWidth,
+      dh: resizedHeight
+    };
+  };
 
+  this.drawMainImage = function (image, mouseDragDistance) {
     getContext().clearRect(0, 0, MAX_WIDHT, MAX_HEIGHT);
-    getContext().drawImage(image, 0, 0, image.width, image.height, dx, dy, resizedWidth, resizedHeight);
+    _this.draw(image, _this.dimensionsToDraw(image, mouseDragDistance));
   };
 
   this.drawNextImage = function (image, mouseDragDistance) {
     if (mouseDragDistance === 0) return;
 
-    var _scaleToFit2 = _this.scaleToFit(image),
-        resizedWidth = _scaleToFit2.resizedWidth,
-        resizedHeight = _scaleToFit2.resizedHeight;
+    var startingPoint = (MAX_WIDHT - mouseDragDistance) * -1;
+    var dimensions = _this.dimensionsToDraw(image, startingPoint);
 
-    var dy = _this.imageMargin(resizedHeight, MAX_HEIGHT);
+    if (mouseDragDistance < 0) {
+      var sw = dimensions.sw,
+          dw = dimensions.dw;
 
-    if (mouseDragDistance > 0) {
-      var startingPoint = MAX_WIDHT - mouseDragDistance;
-      var dx = _this.imageMargin(resizedWidth, MAX_WIDHT) + startingPoint;
+      var proportionToShow = sw * mouseDragDistance / dw;
 
-      getContext().drawImage(image, 0, 0, image.width, image.height, dx, dy, resizedWidth, resizedHeight);
-    } else {
-      var _dy = _this.imageMargin(resizedHeight, MAX_HEIGHT);
-      var begining = image.width * mouseDragDistance / resizedWidth;
-      var sx = image.width - Math.abs(begining);
-
-      getContext().drawImage(image, sx, 0, image.width, image.height, 0, _dy, resizedWidth, resizedHeight);
+      dimensions.sx = sw - Math.abs(proportionToShow);
+      dimensions.dx = 0;
     }
+
+    _this.draw(image, dimensions);
   };
 }
 

--- a/app/script/main.js
+++ b/app/script/main.js
@@ -3971,7 +3971,6 @@ var updateMouseDistance = function updateMouseDistance(currentPosition) {
 var slideDirection = function slideDirection() {
   var mouseDistance = state.current.mouseDistance;
 
-
   return mouseDistance / Math.abs(mouseDistance);
 };
 
@@ -3983,16 +3982,16 @@ var nextIndex = function nextIndex() {
 
   if (mouseDistance === 0) return index;
 
-  var images = gallery.images;
+  var totalImages = gallery.images.length;
 
   var newIndex = index + slideDirection();
 
-  if (newIndex === images.length) {
+  if (newIndex >= totalImages) {
     return 0;
   }
 
   if (newIndex < 0) {
-    return images.length - 1;
+    return totalImages - 1;
   }
 
   return newIndex;
@@ -4031,24 +4030,20 @@ var drawImage = function drawImage() {
 };
 
 var animateTransition = function animateTransition() {
-  var counter = 0;
   var mouseDistance = state.current.mouseDistance;
-
 
   var direction = slideDirection();
 
+  var counter = 0;
   var timer = setInterval(function () {
     counter++;
-
     var increment = 10 * counter * direction;
     var newDistance = mouseDistance + increment;
-    state.setState({
-      mouseDistance: newDistance
-    });
 
+    state.setState({ mouseDistance: newDistance });
     drawImage();
 
-    if (Math.abs(newDistance) >= 800) {
+    if (Math.abs(newDistance) >= $canvas.width) {
       state.setState({ index: nextIndex() });
       stopDragging();
       drawImage();
@@ -4069,9 +4064,7 @@ var handleMove = function handleMove(event) {
     drawImage();
 
     if (shouldSwitchImage()) {
-      state.setState({
-        isDragging: false
-      });
+      state.setState({ isDragging: false });
       animateTransition();
     }
   }

--- a/app/script/main.js
+++ b/app/script/main.js
@@ -3942,9 +3942,6 @@ var Gallery = __webpack_require__(335);
 var State = __webpack_require__(337);
 var Canvas = __webpack_require__(338);
 
-var gallery = new Gallery();
-var canvas = new Canvas();
-
 var state = new State({
   index: 0,
   startX: 0,
@@ -3956,6 +3953,9 @@ var $loading = document.getElementById('loading');
 var $canvas = document.getElementById('slider');
 var BB = $canvas.getBoundingClientRect();
 var MIN_TO_SWITCH = BB.width * 0.5;
+
+var gallery = new Gallery();
+var canvas = new Canvas($canvas);
 
 var updateMouseDistance = function updateMouseDistance(currentPosition) {
   var offsetX = BB.left;
@@ -10575,16 +10575,13 @@ module.exports = State;
 "use strict";
 
 
-var $canvas = document.getElementById('slider');
-var MAX_WIDHT = $canvas.width;
-var MAX_HEIGHT = $canvas.height;
-
-var getContext = function getContext() {
-  return document.getElementById('slider').getContext('2d');
-};
-
-function Canvas() {
+function Canvas(element) {
   var _this = this;
+
+  this.canvas = element;
+  this.maxWidth = element.width;
+  this.maxHeight = element.height;
+  this.context = this.canvas.getContext('2d');
 
   this.scalingFactor = function (original, computed) {
     return computed / original;
@@ -10598,8 +10595,8 @@ function Canvas() {
     var originalWidth = image.width;
     var originalHeight = image.height;
 
-    var xFactor = _this.scalingFactor(originalWidth, MAX_WIDHT);
-    var yFactor = _this.scalingFactor(originalHeight, MAX_HEIGHT);
+    var xFactor = _this.scalingFactor(originalWidth, _this.maxWidth);
+    var yFactor = _this.scalingFactor(originalHeight, _this.maxHeight);
 
     var largestFactor = Math.min(xFactor, yFactor);
 
@@ -10619,7 +10616,7 @@ function Canvas() {
         dw = _ref.dw,
         dh = _ref.dh;
 
-    getContext().drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
+    _this.context.drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
   };
 
   this.dimensionsToDraw = function (image, mouseDragDistance) {
@@ -10632,22 +10629,22 @@ function Canvas() {
       sy: 0,
       sw: image.width,
       sh: image.height,
-      dx: _this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance,
-      dy: _this.imageMargin(resizedHeight, MAX_HEIGHT),
+      dx: _this.imageMargin(resizedWidth, _this.maxWidth) - mouseDragDistance,
+      dy: _this.imageMargin(resizedHeight, _this.maxHeight),
       dw: resizedWidth,
       dh: resizedHeight
     };
   };
 
   this.drawMainImage = function (image, mouseDragDistance) {
-    getContext().clearRect(0, 0, MAX_WIDHT, MAX_HEIGHT);
+    _this.context.clearRect(0, 0, _this.maxWidth, _this.maxHeight);
     _this.draw(image, _this.dimensionsToDraw(image, mouseDragDistance));
   };
 
   this.drawNextImage = function (image, mouseDragDistance) {
     if (mouseDragDistance === 0) return;
 
-    var startingPoint = (MAX_WIDHT - mouseDragDistance) * -1;
+    var startingPoint = (_this.maxWidth - mouseDragDistance) * -1;
     var dimensions = _this.dimensionsToDraw(image, startingPoint);
 
     if (mouseDragDistance < 0) {

--- a/app/script/main.js
+++ b/app/script/main.js
@@ -3952,7 +3952,7 @@ var state = new State({
 var $loading = document.getElementById('loading');
 var $canvas = document.getElementById('slider');
 var BB = $canvas.getBoundingClientRect();
-var MIN_TO_SWITCH = BB.width * 0.5;
+var MIN_TO_SWITCH = BB.width * 0.2;
 
 var gallery = new Gallery();
 var canvas = new Canvas($canvas);
@@ -10612,7 +10612,7 @@ function Canvas(element) {
     _this.context.drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
   };
 
-  this.dimensionsToDraw = function (image, mouseDragDistance) {
+  this.dimensionsToDraw = function (image) {
     var _scaleToFit = _this.scaleToFit(image),
         resizedWidth = _scaleToFit.resizedWidth,
         resizedHeight = _scaleToFit.resizedHeight;
@@ -10622,7 +10622,7 @@ function Canvas(element) {
       sy: 0,
       sw: image.width,
       sh: image.height,
-      dx: _this.imageMargin(resizedWidth, _this.maxWidth) - mouseDragDistance,
+      dx: _this.imageMargin(resizedWidth, _this.maxWidth),
       dy: _this.imageMargin(resizedHeight, _this.maxHeight),
       dw: resizedWidth,
       dh: resizedHeight
@@ -10631,26 +10631,39 @@ function Canvas(element) {
 
   this.drawMainImage = function (image, mouseDragDistance) {
     _this.context.clearRect(0, 0, _this.maxWidth, _this.maxHeight);
-    _this.draw(image, _this.dimensionsToDraw(image, mouseDragDistance));
+    var dimensions = _this.dimensionsToDraw(image);
+    dimensions.dx = dimensions.dx - mouseDragDistance;
+    _this.draw(image, dimensions);
   };
 
   this.drawNextImage = function (image, mouseDragDistance) {
     if (mouseDragDistance === 0) return;
 
-    var startingPoint = (_this.maxWidth - mouseDragDistance) * -1;
-    var dimensions = _this.dimensionsToDraw(image, startingPoint);
+    if (mouseDragDistance > 0) {
+      var dimensions = _this.dimensionsToDraw(image);
+      dimensions.dx = dimensions.dx + _this.maxWidth - mouseDragDistance;
 
-    if (mouseDragDistance < 0) {
-      var sw = dimensions.sw,
-          dw = dimensions.dw;
-
-      var proportionToShow = sw * mouseDragDistance / dw;
-
-      dimensions.sx = sw - Math.abs(proportionToShow);
-      dimensions.dx = 0;
+      _this.draw(image, dimensions);
+      return;
     }
 
-    _this.draw(image, dimensions);
+    if (mouseDragDistance < 0) {
+      var _dimensions = _this.dimensionsToDraw(image);
+      var dx = _dimensions.dx,
+          sw = _dimensions.sw,
+          dw = _dimensions.dw;
+
+
+      if (Math.abs(mouseDragDistance) > dx) {
+        var diff = Math.abs(mouseDragDistance) - dx;
+        var proportionToShow = sw * diff / dw;
+
+        _dimensions.sx = sw - Math.abs(proportionToShow);
+        _dimensions.dx = 0;
+
+        _this.draw(image, _dimensions);
+      }
+    }
   };
 }
 

--- a/app/script/src/canvas/index.js
+++ b/app/script/src/canvas/index.js
@@ -26,52 +26,48 @@ function Canvas() {
     return { resizedWidth, resizedHeight }
   }
 
-  this.drawImage = (image, mouseDragDistance) => {
-    const { resizedWidth, resizedHeight } = this.scaleToFit(image)
-
-    const dx = this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance
-    const dy = this.imageMargin(resizedHeight, MAX_HEIGHT)
-
-    getContext().clearRect(0, 0, MAX_WIDHT, MAX_HEIGHT)
+  this.draw = (image, { sx, sy, sw, sh, dx, dy, dw, dh }) => {
     getContext().drawImage(
       image,
-      0, 0,
-      image.width, image.height,
-      dx, dy,
-      resizedWidth, resizedHeight
+      sx, sy, sw, sh, dx, dy, dw, dh
     )
+  }
+
+  this.dimensionsToDraw = (image, mouseDragDistance) => {
+    const { resizedWidth, resizedHeight } = this.scaleToFit(image)
+
+    return {
+      sx: 0,
+      sy: 0,
+      sw: image.width,
+      sh: image.height,
+      dx: this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance,
+      dy: this.imageMargin(resizedHeight, MAX_HEIGHT),
+      dw: resizedWidth,
+      dh: resizedHeight
+    }
+  }
+
+  this.drawMainImage = (image, mouseDragDistance) => {
+    getContext().clearRect(0, 0, MAX_WIDHT, MAX_HEIGHT)
+    this.draw(image, this.dimensionsToDraw(image, mouseDragDistance))
   }
 
   this.drawNextImage = (image, mouseDragDistance) => {
     if (mouseDragDistance === 0) return
 
-    const { resizedWidth, resizedHeight } = this.scaleToFit(image)
-    const dy = this.imageMargin(resizedHeight, MAX_HEIGHT)
+    const startingPoint = (MAX_WIDHT - mouseDragDistance) * -1
+    const dimensions = this.dimensionsToDraw(image, startingPoint)
 
-    if (mouseDragDistance > 0) {
-      const startingPoint = MAX_WIDHT - mouseDragDistance
-      const dx = this.imageMargin(resizedWidth, MAX_WIDHT) + startingPoint
+    if (mouseDragDistance < 0) {
+      const { sw, dw } = dimensions
+      const proportionToShow = (sw * mouseDragDistance) / dw
 
-      getContext().drawImage(
-        image,
-        0, 0,
-        image.width, image.height,
-        dx, dy,
-        resizedWidth, resizedHeight
-      )
-    } else {
-      const dy = this.imageMargin(resizedHeight, MAX_HEIGHT)
-      const begining = (image.width * mouseDragDistance) / resizedWidth
-      const sx = image.width - Math.abs(begining)
-
-      getContext().drawImage(
-        image,
-        sx, 0,
-        image.width, image.height,
-        0, dy,
-        resizedWidth, resizedHeight
-      )
+      dimensions.sx = sw - Math.abs(proportionToShow)
+      dimensions.dx = 0
     }
+
+    this.draw(image, dimensions)
   }
 }
 

--- a/app/script/src/canvas/index.js
+++ b/app/script/src/canvas/index.js
@@ -1,10 +1,9 @@
-const $canvas = document.getElementById('slider')
-const MAX_WIDHT = $canvas.width
-const MAX_HEIGHT = $canvas.height
+function Canvas(element) {
+  this.canvas = element
+  this.maxWidth = element.width
+  this.maxHeight = element.height
+  this.context = this.canvas.getContext('2d')
 
-const getContext = () => document.getElementById('slider').getContext('2d')
-
-function Canvas() {
   this.scalingFactor = (original, computed) => computed / original
 
   this.imageMargin = (imageSize, maxSize) => (
@@ -15,8 +14,8 @@ function Canvas() {
     const originalWidth = image.width
     const originalHeight = image.height
 
-    const xFactor = this.scalingFactor(originalWidth, MAX_WIDHT)
-    const yFactor = this.scalingFactor(originalHeight, MAX_HEIGHT)
+    const xFactor = this.scalingFactor(originalWidth, this.maxWidth)
+    const yFactor = this.scalingFactor(originalHeight, this.maxHeight)
 
     const largestFactor = Math.min(xFactor, yFactor)
 
@@ -27,7 +26,7 @@ function Canvas() {
   }
 
   this.draw = (image, { sx, sy, sw, sh, dx, dy, dw, dh }) => {
-    getContext().drawImage(
+    this.context.drawImage(
       image,
       sx, sy, sw, sh, dx, dy, dw, dh
     )
@@ -41,22 +40,22 @@ function Canvas() {
       sy: 0,
       sw: image.width,
       sh: image.height,
-      dx: this.imageMargin(resizedWidth, MAX_WIDHT) - mouseDragDistance,
-      dy: this.imageMargin(resizedHeight, MAX_HEIGHT),
+      dx: this.imageMargin(resizedWidth, this.maxWidth) - mouseDragDistance,
+      dy: this.imageMargin(resizedHeight, this.maxHeight),
       dw: resizedWidth,
       dh: resizedHeight
     }
   }
 
   this.drawMainImage = (image, mouseDragDistance) => {
-    getContext().clearRect(0, 0, MAX_WIDHT, MAX_HEIGHT)
+    this.context.clearRect(0, 0, this.maxWidth, this.maxHeight)
     this.draw(image, this.dimensionsToDraw(image, mouseDragDistance))
   }
 
   this.drawNextImage = (image, mouseDragDistance) => {
     if (mouseDragDistance === 0) return
 
-    const startingPoint = (MAX_WIDHT - mouseDragDistance) * -1
+    const startingPoint = (this.maxWidth - mouseDragDistance) * -1
     const dimensions = this.dimensionsToDraw(image, startingPoint)
 
     if (mouseDragDistance < 0) {

--- a/app/script/src/canvas/index.js
+++ b/app/script/src/canvas/index.js
@@ -32,7 +32,7 @@ function Canvas(element) {
     )
   }
 
-  this.dimensionsToDraw = (image, mouseDragDistance) => {
+  this.dimensionsToDraw = (image) => {
     const { resizedWidth, resizedHeight } = this.scaleToFit(image)
 
     return {
@@ -40,7 +40,7 @@ function Canvas(element) {
       sy: 0,
       sw: image.width,
       sh: image.height,
-      dx: this.imageMargin(resizedWidth, this.maxWidth) - mouseDragDistance,
+      dx: this.imageMargin(resizedWidth, this.maxWidth),
       dy: this.imageMargin(resizedHeight, this.maxHeight),
       dw: resizedWidth,
       dh: resizedHeight
@@ -49,24 +49,36 @@ function Canvas(element) {
 
   this.drawMainImage = (image, mouseDragDistance) => {
     this.context.clearRect(0, 0, this.maxWidth, this.maxHeight)
-    this.draw(image, this.dimensionsToDraw(image, mouseDragDistance))
+    const dimensions = this.dimensionsToDraw(image)
+    dimensions.dx = dimensions.dx - mouseDragDistance
+    this.draw(image, dimensions)
   }
 
   this.drawNextImage = (image, mouseDragDistance) => {
     if (mouseDragDistance === 0) return
 
-    const startingPoint = (this.maxWidth - mouseDragDistance) * -1
-    const dimensions = this.dimensionsToDraw(image, startingPoint)
+    if (mouseDragDistance > 0) {
+      const dimensions = this.dimensionsToDraw(image)
+      dimensions.dx = dimensions.dx + this.maxWidth - mouseDragDistance
 
-    if (mouseDragDistance < 0) {
-      const { sw, dw } = dimensions
-      const proportionToShow = (sw * mouseDragDistance) / dw
-
-      dimensions.sx = sw - Math.abs(proportionToShow)
-      dimensions.dx = 0
+      this.draw(image, dimensions)
+      return
     }
 
-    this.draw(image, dimensions)
+    if (mouseDragDistance < 0) {
+      const dimensions = this.dimensionsToDraw(image)
+      const { dx, sw, dw } = dimensions
+
+      if (Math.abs(mouseDragDistance) > dx) {
+        const diff = Math.abs(mouseDragDistance) - dx
+        const proportionToShow = (sw * diff) / dw
+
+        dimensions.sx = sw - Math.abs(proportionToShow)
+        dimensions.dx = 0
+
+        this.draw(image, dimensions)
+      }
+    }
   }
 }
 

--- a/app/script/src/index.js
+++ b/app/script/src/index.js
@@ -80,7 +80,7 @@ const drawImage = () => {
   const { index, mouseDistance } = state.current
   const images = gallery.images
 
-  canvas.drawImage(images[index], mouseDistance)
+  canvas.drawMainImage(images[index], mouseDistance)
   canvas.drawNextImage(images[nextIndex()], mouseDistance)
 }
 

--- a/app/script/src/index.js
+++ b/app/script/src/index.js
@@ -15,7 +15,7 @@ const state = new State({
 const $loading = document.getElementById('loading')
 const $canvas = document.getElementById('slider')
 const BB = $canvas.getBoundingClientRect()
-const MIN_TO_SWITCH = BB.width * 0.5
+const MIN_TO_SWITCH = BB.width * 0.2
 
 const gallery = new Gallery()
 const canvas = new Canvas($canvas)

--- a/app/script/src/index.js
+++ b/app/script/src/index.js
@@ -32,7 +32,6 @@ const updateMouseDistance = currentPosition => {
 
 const slideDirection = () => {
   const { mouseDistance } = state.current
-
   return mouseDistance / Math.abs(mouseDistance)
 }
 
@@ -41,16 +40,16 @@ const nextIndex = () => {
 
   if (mouseDistance === 0) return index
 
-  const images = gallery.images
+  const totalImages = gallery.images.length
 
   let newIndex = index + slideDirection()
 
-  if (newIndex === images.length) {
+  if (newIndex >= totalImages) {
     return 0
   }
 
   if (newIndex < 0) {
-    return images.length - 1
+    return totalImages - 1
   }
 
   return newIndex
@@ -85,23 +84,19 @@ const drawImage = () => {
 }
 
 const animateTransition = () => {
-  let counter = 0
   const { mouseDistance } = state.current
-
   const direction = slideDirection()
 
-  const timer = setInterval(function() {
+  let counter = 0
+  const timer = setInterval(() => {
     counter++
-
     const increment = (10 * counter) * direction
     const newDistance = mouseDistance + increment
-    state.setState({
-      mouseDistance: newDistance
-    })
 
+    state.setState({ mouseDistance: newDistance })
     drawImage()
 
-    if (Math.abs(newDistance) >= 800) {
+    if (Math.abs(newDistance) >= $canvas.width) {
       state.setState({ index: nextIndex() })
       stopDragging()
       drawImage()
@@ -121,9 +116,7 @@ const handleMove = event => {
     drawImage()
 
     if (shouldSwitchImage()) {
-      state.setState({
-        isDragging: false
-      })
+      state.setState({ isDragging: false })
       animateTransition()
     }
   }

--- a/app/script/src/index.js
+++ b/app/script/src/index.js
@@ -5,9 +5,6 @@ const Gallery = require('./gallery')
 const State = require('./state')
 const Canvas = require('./canvas')
 
-const gallery = new Gallery()
-const canvas = new Canvas()
-
 const state = new State({
   index: 0,
   startX: 0,
@@ -19,6 +16,9 @@ const $loading = document.getElementById('loading')
 const $canvas = document.getElementById('slider')
 const BB = $canvas.getBoundingClientRect()
 const MIN_TO_SWITCH = BB.width * 0.5
+
+const gallery = new Gallery()
+const canvas = new Canvas($canvas)
 
 const updateMouseDistance = currentPosition => {
   const offsetX = BB.left


### PR DESCRIPTION
- Improved Canvas module code;
- Consider origin image width proportion so it’s margin is shown correctly when dragging to previous image